### PR TITLE
chore(helm,compose): update influxdb

### DIFF
--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -800,6 +800,7 @@ influxdb2:
         BUCKET_ID=$(influx bucket list | grep "$DOCKER_INFLUXDB_INIT_BUCKET" | awk '{print $1}')
         influx v1 dbrp create --db ${DOCKER_INFLUXDB_INIT_BUCKET} --rp ${DOCKER_INFLUXDB_INIT_RETENTION} --bucket-id ${BUCKET_ID} --default
         influx v1 auth create --username ${DOCKER_INFLUXDB_INIT_USERNAME} --password ${DOCKER_INFLUXDB_INIT_PASSWORD} --write-bucket ${BUCKET_ID} --org ${DOCKER_INFLUXDB_INIT_ORG}
+        influx bucket create --name ${DOCKER_INFLUXDB_BUCKET_VDP} --org ${DOCKER_INFLUXDB_INIT_ORG} --token ${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN} --retention ${DOCKER_INFLUXDB_INIT_RETENTION}
 
 jaeger:
   provisionDataStore:

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -792,6 +792,9 @@ influxdb2:
     user: "admin"
     password: "password"
     token: "i-love-instill-ai"
+  env:
+    - name: DOCKER_INFLUXDB_BUCKET_VDP
+      value: vdp
   initScripts:
     enabled: true
     scripts:

--- a/configs/influxdb/initdb.sh
+++ b/configs/influxdb/initdb.sh
@@ -10,3 +10,9 @@ influx v1 auth create \
   --password ${DOCKER_INFLUXDB_INIT_PASSWORD} \
   --write-bucket ${BUCKET_ID} \
   --org ${DOCKER_INFLUXDB_INIT_ORG}
+
+influx bucket create \
+  --name ${DOCKER_INFLUXDB_BUCKET_VDP} \
+  --org ${DOCKER_INFLUXDB_INIT_ORG} \
+  --token ${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN} \
+  --retention ${DOCKER_INFLUXDB_INIT_RETENTION}

--- a/configs/otel-collector/config.yaml
+++ b/configs/otel-collector/config.yaml
@@ -39,7 +39,3 @@ service:
       receivers: [otlp]
       processors: [memory_limiter, batch]
       exporters: [logging, prometheus]
-    logs:
-      receivers: [otlp]
-      processors: [memory_limiter, batch]
-      exporters: [logging]

--- a/docker-compose.observe.yml
+++ b/docker-compose.observe.yml
@@ -1,22 +1,6 @@
 version: "3.9"
 
 services:
-  influxdb:
-    container_name: ${INFLUXDB_HOST}
-    image: ${INFLUXDB_IMAGE}:${INFLUXDB_VERSION}-alpine
-    environment:
-      DOCKER_INFLUXDB_INIT_MODE: setup
-      DOCKER_INFLUXDB_INIT_USERNAME: admin
-      DOCKER_INFLUXDB_INIT_PASSWORD: password
-      DOCKER_INFLUXDB_INIT_ORG: instill-ai
-      DOCKER_INFLUXDB_INIT_BUCKET: krakend
-      DOCKER_INFLUXDB_INIT_RETENTION: 1w
-      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: i-love-instill-ai
-    volumes:
-      - ${OBSERVE_CONFIG_DIR_PATH}/influxdb:/docker-entrypoint-initdb.d
-    ports:
-      - ${INFLUXDB_PORT}:8086
-
   otel_collector:
     container_name: ${OTEL_COLLECTOR_HOST}
     image: ${OTEL_COLLECTOR_IMAGE}:${OTEL_COLLECTOR_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,3 +202,20 @@ services:
       ETCDCTL_API: ${ETCDCTL_API}
       ETCD_AUTO_COMPACTION_MODE: ${ETCD_AUTO_COMPACTION_MODE}
       ETCD_AUTO_COMPACTION_RETENTION: ${ETCD_AUTO_COMPACTION_RETENTION}
+
+  influxdb:
+    container_name: ${INFLUXDB_HOST}
+    image: ${INFLUXDB_IMAGE}:${INFLUXDB_VERSION}-alpine
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: password
+      DOCKER_INFLUXDB_INIT_ORG: instill-ai
+      DOCKER_INFLUXDB_INIT_BUCKET: krakend
+      DOCKER_INFLUXDB_INIT_RETENTION: 1w
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: i-love-instill-ai
+      DOCKER_INFLUXDB_BUCKET_VDP: vdp
+    volumes:
+      - ${OBSERVE_CONFIG_DIR_PATH}/influxdb:/docker-entrypoint-initdb.d
+    ports:
+      - ${INFLUXDB_PORT}:8086


### PR DESCRIPTION
Because

- make `influxdb` standard since `metric` will need to be recorded at all time

This commit

- move `influxdb` from `docker-compose.observe.yaml` to `docker-compose.yaml`
- add `vdp` bucket for `vdp` related metrics
