### PR TITLE
ci(base): update variable names

### DIFF
--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+      - main
   workflow_call:
     inputs:
       component:

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -1,6 +1,10 @@
 name: Integration Test Reusable (backend)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects  
   workflow_call:
     inputs:
       component:
@@ -55,9 +59,10 @@ jobs:
       - name: Run ${{ inputs.component }} integration test (latest)
         if: inputs.target == 'latest'
         run: |
-          git clone -b https://github.com/instill-ai/${{ inputs.component }}.git
+          git clone https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_BASE_HOST=localhost API_GATEWAY_BASE_HOST=${API_GATEWAY_BASE_PORT}
+          make integration-test API_GATEWAY_BASE_HOST=localhost API_GATEWAY_BASE_PORT=${API_GATEWAY_BASE_PORT}
+
 
       - name: Uppercase component name
         if: inputs.target == 'release'
@@ -80,4 +85,4 @@ jobs:
         run: |
           git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_BASE_HOST=localhost API_GATEWAY_BASE_HOST=${API_GATEWAY_BASE_PORT}
+          make integration-test API_GATEWAY_BASE_HOST=localhost API_GATEWAY_BASE_PORT=${API_GATEWAY_BASE_PORT}

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects  
+      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects
   workflow_call:
     inputs:
       component:
@@ -15,9 +15,24 @@ on:
         type: string
 
 jobs:
-  integration-test:
+  integration-test-latest:
+    if: inputs.target != 'release'
     runs-on: ubuntu-latest
     steps:
+      # mono occupies port 8084 which conflicts with mgmt-backend
+      - name: Stop mono service
+        run: |
+          sudo kill -9 `sudo lsof -t -i:8084`
+          sudo lsof -i -P -n | grep LISTEN
+
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
+
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
@@ -28,23 +43,9 @@ jobs:
         with:
           envFile: .env
 
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
       - name: Install k6
         run: |
           curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
-
-      - name: Free disk space
-        run: |
-          df --human-readable
-          sudo apt clean
-          docker rmi $(docker image ls --all --quiet)
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df --human-readable
 
       - name: Launch Instill Base (latest)
         if: inputs.target == 'latest'
@@ -63,6 +64,37 @@ jobs:
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_BASE_HOST=localhost API_GATEWAY_BASE_PORT=${API_GATEWAY_BASE_PORT}
 
+  integration-test-release:
+    if: inputs.target == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      # mono occupies port 8084 which conflicts with mgmt-backend
+      - name: Stop mono service
+        run: |
+          sudo kill -9 `sudo lsof -t -i:8084`
+          sudo lsof -i -P -n | grep LISTEN
+
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Install k6
+        run: |
+          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
 
       - name: Uppercase component name
         if: inputs.target == 'release'

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+      - main
   workflow_call:
     inputs:
       target:

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -1,6 +1,10 @@
 name: Integration Test Reusable (console)
 
-on:
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects  
   workflow_call:
     inputs:
       target:

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -1,10 +1,10 @@
 name: Integration Test Reusable (console)
 
-on: 
+on:
   workflow_dispatch:
   push:
     branches:
-      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects  
+      - ins-1105-fix-the-the-integration-test-cicd-in-all-projects
   workflow_call:
     inputs:
       target:
@@ -12,19 +12,10 @@ on:
         type: string
 
 jobs:
-  integration-test:
+  integration-test-latest:
+    if: inputs.target != 'release'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/base
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -39,13 +30,69 @@ jobs:
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file (base)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
       - name: Launch Instill Base (latest)
+        if: inputs.target == 'latest'
+        run: |
+          CONSOLE_PUBLIC_API_GATEWAY_BASE_HOST=api-gateway-base \
+          CONSOLE_PUBLIC_API_GATEWAY_VDP_HOST=api-gateway-vdp \
+          CONSOLE_PUBLIC_API_GATEWAY_MODEL_HOST=api-gateway-model \
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull          
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (latest)
         if: inputs.target == 'latest'
         run: |
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
-          CONSOLE_URL_HOST=console \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill Model (latest)
+        if: inputs.target == 'latest'
+        run: |
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull          
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
@@ -56,23 +103,99 @@ jobs:
           git clone https://github.com/instill-ai/console.git
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
           docker run -t --rm \
-            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://${CONSOLE_HOST}:${CONSOLE_PORT} \
-            -e NEXT_PUBLIC_API_GATEWAY_BASE_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT} \
-            -e NEXT_SERVER_API_GATEWAY_BASE_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT} \
             -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=local-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \
+            -e NEXT_PUBLIC_BASE_API_GATEWAY_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT}  \
+            -e NEXT_SERVER_BASE_API_GATEWAY_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT}  \
+            -e NEXT_PUBLIC_VDP_API_GATEWAY_URL=http://${API_GATEWAY_VDP_HOST}:${API_GATEWAY_VDP_PORT}  \
+            -e NEXT_SERVER_VDP_API_GATEWAY_URL=http://${API_GATEWAY_VDP_HOST}:${API_GATEWAY_VDP_PORT}  \
+            -e NEXT_PUBLIC_MODEL_API_GATEWAY_URL=http://${API_GATEWAY_MODEL_HOST}:${API_GATEWAY_MODEL_PORT}  \
+            -e NEXT_SERVER_MODEL_API_GATEWAY_URL=http://${API_GATEWAY_MODEL_HOST}:${API_GATEWAY_MODEL_PORT}  \
             -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
             -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
             --network instill-network \
             --entrypoint ./entrypoint-playwright.sh \
-            --name console-integration-test console-playwright:latest
+            --name console-integration-test \
+            console-playwright:latest
+
+  integration-test-release:
+    if: inputs.target == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      # mono occupies port 8084 which conflicts with mgmt-backend
+      - name: Stop mono service
+        run: |
+          sudo kill -9 `sudo lsof -t -i:8084`
+          sudo lsof -i -P -n | grep LISTEN
+
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
+
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file (base)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
 
       - name: Launch Instill Base (release)
         if: inputs.target == 'release'
         run: |
+          CONSOLE_PUBLIC_API_GATEWAY_BASE_HOST=api-gateway-base \
+          CONSOLE_PUBLIC_API_GATEWAY_VDP_HOST=api-gateway-vdp \
+          CONSOLE_PUBLIC_API_GATEWAY_MODEL_HOST=api-gateway-model \
           EDITION=local-ce:test \
-          CONSOLE_URL_HOST=console \
           docker compose up -d --quiet-pull
           EDITION=local-ce:test \
+          docker compose rm -f
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (release)
+        if: inputs.target == 'latest'
+        run: |
+          EDITION=local-ce:test \
+          docker compose up -d --quiet-pull
+          EDITION=local-ce:test \
+          docker compose rm -f
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill Model (release)
+        if: inputs.target == 'latest'
+        run: |
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
+          EDITION=local-ce:test \
+          docker compose up -d --quiet-pull
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
+          EDITION=local-ce:test \          
           docker compose rm -f
 
       - name: Run console integration test (release)
@@ -81,12 +204,18 @@ jobs:
           git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
           docker run -t --rm \
-            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://${CONSOLE_HOST}:${CONSOLE_PORT} \
-            -e NEXT_PUBLIC_API_GATEWAY_BASE_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT} \
-            -e NEXT_SERVER_API_GATEWAY_BASE_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT} \
             -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=local-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \
+            -e NEXT_PUBLIC_BASE_API_GATEWAY_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT}  \
+            -e NEXT_SERVER_BASE_API_GATEWAY_URL=http://${API_GATEWAY_BASE_HOST}:${API_GATEWAY_BASE_PORT}  \
+            -e NEXT_PUBLIC_VDP_API_GATEWAY_URL=http://${API_GATEWAY_VDP_HOST}:${API_GATEWAY_VDP_PORT}  \
+            -e NEXT_SERVER_VDP_API_GATEWAY_URL=http://${API_GATEWAY_VDP_HOST}:${API_GATEWAY_VDP_PORT}  \
+            -e NEXT_PUBLIC_MODEL_API_GATEWAY_URL=http://${API_GATEWAY_MODEL_HOST}:${API_GATEWAY_MODEL_PORT}  \
+            -e NEXT_SERVER_MODEL_API_GATEWAY_URL=http://${API_GATEWAY_MODEL_HOST}:${API_GATEWAY_MODEL_PORT}  \
             -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
             -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
             --network instill-network \
             --entrypoint ./entrypoint-playwright.sh \
-            --name console-integration-test console-playwright:${{ env.CONSOLE_VERSION }}
+            --name console-integration-test \
+            console-playwright:latest

--- a/.github/workflows/integration-test-latest.yml
+++ b/.github/workflows/integration-test-latest.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
       target: latest
   console:
-    uses: instill-ai/base/.github/workflows/integration-test-console.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+    uses: instill-ai/base/.github/workflows/integration-test-console.yml@main
     with:
       target: latest

--- a/.github/workflows/integration-test-latest.yml
+++ b/.github/workflows/integration-test-latest.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@main
+    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
     with:
       component: ${{ matrix.component }}
       target: latest
-  # console:
-  #   uses: instill-ai/base/.github/workflows/integration-test-console.yml@main
-  #   with:
-  #     target: latest
+  console:
+    uses: instill-ai/base/.github/workflows/integration-test-console.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+    with:
+      target: latest

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@main
+    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
     with:
       component: ${{ matrix.component }}
       target: release
-  # console:
-  #   uses: instill-ai/base/.github/workflows/integration-test-console.yml@main
-  #   with:
-  #     target: release
+  console:
+    uses: instill-ai/base/.github/workflows/integration-test-console.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+    with:
+      target: release

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
       target: release
   console:
-    uses: instill-ai/base/.github/workflows/integration-test-console.yml@ins-1105-fix-the-the-integration-test-cicd-in-all-projects
+    uses: instill-ai/base/.github/workflows/integration-test-console.yml@main
     with:
       target: release


### PR DESCRIPTION
Because

- the GA integration test needs to adopt the new project structure

This commit

- update env variables names
- adopt new project settings
