### PR TITLE
chore(helm): add missing mgmt-backend helm configs

### DIFF
--- a/charts/base/templates/mgmt-backend/configmap.yaml
+++ b/charts/base/templates/mgmt-backend/configmap.yaml
@@ -35,3 +35,18 @@ data:
       redis:
         redisoptions:
           addr: {{ default (include "base.redis.addr" .) .Values.redis.external.addr }}
+    influxdb:
+      host: {{ template "base.influxdb" . }}
+      port: {{ default (include "base.influxdb.port" .) .Values.influxdb2.service.port }}
+      token: {{ .Values.influxdb2.adminUser.token }}
+      org: {{ .Values.influxdb2.adminUser.organization }}
+      bucket: {{ (index .Values.influxdb2.env 0).value }}
+      flushinterval: 10 # In seconds for non-blocking batch mode
+      https:
+        cert:
+        key:
+    log:
+      external: {{ .Values.tags.observability }}
+      otelcollector:
+        host: {{ template "base.otel" . }}
+        port: {{ template "base.otel.port" . }}

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -794,7 +794,7 @@ influxdb2:
     token: "i-love-instill-ai"
   env:
     - name: DOCKER_INFLUXDB_BUCKET_VDP
-      value: vdp
+      value: instill-ai
   initScripts:
     enabled: true
     scripts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,7 +212,7 @@ services:
       DOCKER_INFLUXDB_INIT_BUCKET: krakend
       DOCKER_INFLUXDB_INIT_RETENTION: 1w
       DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: i-love-instill-ai
-      DOCKER_INFLUXDB_BUCKET_VDP: vdp
+      DOCKER_INFLUXDB_BUCKET_VDP: instill-ai
     volumes:
       - ${OBSERVE_CONFIG_DIR_PATH}/influxdb:/docker-entrypoint-initdb.d
     ports:


### PR DESCRIPTION
Because

- add missing mgmt-backend helm configs

This commit

- add missing mgmt-backend helm configs
