### PR TITLE
chore(helm): add extra env to mgmt_backend_init

### DIFF
--- a/charts/base/templates/mgmt-backend/deployment.yaml
+++ b/charts/base/templates/mgmt-backend/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             - name: config
               mountPath: {{ .Values.mgmtBackend.configPath }}
               subPath: config.yaml
+          {{- with .Values.mgmtBackend.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- with .Values.mgmtBackend.extraInitContainers }}
         {{- toYaml . | indent 8 }}
         {{- end }}


### PR DESCRIPTION
Because

- we need to pass some env variable into mgmt_backend_init

This commit

- add extra env to mgmt_backend_init
