### PR TITLE
chore(base): add influx cloud config

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -29,8 +29,6 @@ dependencies:
   - name: influxdb2
     repository: https://helm.influxdata.com
     version: 2.1.1
-    tags:
-      - observability
   - name: jaeger
     repository: https://jaegertracing.github.io/helm-charts
     version: 0.71.2

--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -43,9 +43,9 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     version: 22.6.2
     tags:
-      - promethueus-stack
+      - promethueusStack
   - name: grafana
     repository: https://grafana.github.io/helm-charts
     version: 6.56.6
     tags:
-      - promethueus-stack
+      - promethueusStack

--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -34,18 +34,18 @@ dependencies:
     version: 0.71.2
     tags:
       - observability
-  - name: prometheus
-    repository: https://prometheus-community.github.io/helm-charts
-    version: 22.6.2
-    tags:
-      - observability
-  - name: grafana
-    repository: https://grafana.github.io/helm-charts
-    version: 6.56.6
-    tags:
-      - observability
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     version: 0.59.1
     tags:
       - observability
+  - name: prometheus
+    repository: https://prometheus-community.github.io/helm-charts
+    version: 22.6.2
+    tags:
+      - promethueus-stack
+  - name: grafana
+    repository: https://grafana.github.io/helm-charts
+    version: 6.56.6
+    tags:
+      - promethueus-stack

--- a/charts/base/templates/_helpers.tpl
+++ b/charts/base/templates/_helpers.tpl
@@ -253,10 +253,6 @@ app.kubernetes.io/name: {{ include "base.name" . }}
   {{- printf "8086" -}}
 {{- end -}}
 
-{{- define "base.influxdb.url" -}}
-  {{- printf "http://%s:%s" (include "base.influxdb" .) (include "base.influxdb.port" .) -}}
-{{- end -}}
-
 {{- define "base.jaeger" -}}
   {{- printf "base-jaeger-collector" -}}
 {{- end -}}

--- a/charts/base/templates/api-gateway-base/deployment.yaml
+++ b/charts/base/templates/api-gateway-base/deployment.yaml
@@ -49,10 +49,8 @@ spec:
           command: ['sh', '-c']
           args:
           - >
-            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PORT}/v1alpha/health/mgmt)" != "200" ]]; do echo waiting for mgmt-backend; sleep 1; done
-          {{- if .Values.tags.observability }}
-            && while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${INFLUXDB_HOST}:${INFLUXDB_PORT}/health)" != "200" ]]; do echo waiting for influxdb; sleep 1; done
-          {{- end }}
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PORT}/v1alpha/health/mgmt)" != "200" ]]; do echo waiting for mgmt-backend; sleep 1; done &&
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${INFLUXDB_HOST}:${INFLUXDB_PORT}/health)" != "200" ]]; do echo waiting for influxdb; sleep 1; done
           env:
             - name: MGMT_BACKEND_HOST
               value: "{{ template "base.mgmtBackend" . }}"

--- a/charts/base/templates/mgmt-backend/configmap.yaml
+++ b/charts/base/templates/mgmt-backend/configmap.yaml
@@ -36,10 +36,10 @@ data:
         redisoptions:
           addr: {{ default (include "base.redis.addr" .) .Values.redis.external.addr }}
     influxdb:
-      url: {{ template "base.influxdb.url" . }}
-      token: {{ .Values.influxdb2.adminUser.token }}
-      org: {{ .Values.influxdb2.adminUser.organization }}
-      bucket: {{ (index .Values.influxdb2.env 0).value }}
+      url: {{ .Values.influxdbCloud.url }}
+      token: {{ .Values.influxdbCloud.token }}
+      org: {{ .Values.influxdbCloud.organization }}
+      bucket: {{ .Values.influxdbCloud.bucket }}
       flushinterval: 10 # In seconds for non-blocking batch mode
       https:
         cert:

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -759,6 +759,12 @@ temporal:
         default_to_namespace: default
         issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums
 
+influxdbCloud:
+  url: 'https://instill.com'
+  token: "IloveInstill"
+  organization: "instill-ai"
+  bucket: 'Instill'
+
 elasticsearch:
   # -- If external Elasticsearch is used, set "enabled" to false
   # and fill the connection informations in "external" section

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -759,12 +759,6 @@ temporal:
         default_to_namespace: default
         issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums
 
-influxdbCloud:
-  url: 'https://instill.com'
-  token: "IloveInstill"
-  organization: "instill-ai"
-  bucket: 'Instill'
-
 elasticsearch:
   # -- If external Elasticsearch is used, set "enabled" to false
   # and fill the connection informations in "external" section
@@ -786,6 +780,12 @@ elasticsearch:
       xpack.security.enabled: false
   ## -- The configuration of external Elasticsearch
   external:
+
+influxdbCloud:
+  url: "http://base-influxdb2:8086"
+  token: "i-love-instill-ai"
+  organization: "instill-ai"
+  bucket: "instill-ai"
 
 influxdb2:
   enabled: true
@@ -964,3 +964,4 @@ grafana:
 
 tags:
   observability: true
+  promethueus-stack: false

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -964,4 +964,4 @@ grafana:
 
 tags:
   observability: true
-  promethueus-stack: false
+  promethueusStack: false


### PR DESCRIPTION
Because

- add influxdb cloud section to pass different values than self-hosted influxdb
- separate out observability and prometheus-stack

This commit

- add influx cloud config section in values.yaml
- add prometheusStack tag
