### PR TITLE
ci(workflow): update integration test release and latest workflow

### DIFF
--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -1,10 +1,6 @@
 name: Integration Test Reusable (backend)
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
   workflow_call:
     inputs:
       component:

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -1,10 +1,6 @@
 name: Integration Test Reusable (console)
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
   workflow_call:
     inputs:
       target:

--- a/.github/workflows/integration-test-latest.yml
+++ b/.github/workflows/integration-test-latest.yml
@@ -1,7 +1,6 @@
 name: Integration Test (latest)
 
 on:
-  workflow_dispatch:
   push:
     branches-ignore:
       - release-please--branches--main

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -2,9 +2,6 @@ name: Integration Test (release)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
 
 jobs:
   backend:


### PR DESCRIPTION
Because

- we have to trigger integration test latest and release when push in main branch.

This commit

- update integration test release and latest workflow
