### PR TITLE
ci(workflow): add integration-test-latest|release workflow for mac

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -11,7 +11,7 @@ on:
         type: string    
 
 jobs:
-  helm-integration-test-latest:
+  helm-integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,80 @@ jobs:
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
-  helm-integration-test-release:
+  helm-integration-test-latest-mac:
+    if: inputs.target == 'latest'
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install helm
+          brew install jq
+          brew install make
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Check if Helm release exists
+        id: check-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'base'; then
+            echo "Helm release 'base' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'base' not found."
+          fi
+
+      - name: Uninstall Helm Release
+        if: steps.check-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+
+      - name: Launch Helm Instill Base (latest)
+        run: |
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set apiGateway.image.tag=latest \
+            --set mgmtBackend.image.tag=latest \
+            --set console.image.tag=latest \
+            --set tags.observability=false
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of base-api-gateway
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=basee" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+
+      - name: Run ${{ inputs.component }} integration test (latest)
+        run: |
+          git clone https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+      - name: Uninstall Base Helm Release
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+
+  helm-integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -107,7 +180,7 @@ jobs:
 
       - name: Install k6
         run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin    
+          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
 
       - name: Uppercase component name
         id: uppercase
@@ -134,7 +207,7 @@ jobs:
         run: |
           API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
           kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
-          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done 
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
 
       - name: Run ${{ inputs.component }} integration test (release)
         env:
@@ -143,3 +216,83 @@ jobs:
           git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+  helm-integration-test-release-mac:
+    if: inputs.target == 'release'
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install helm
+          brew install jq
+          brew install make
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Check if Helm release exists
+        id: check-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'base'; then
+            echo "Helm release 'base' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'base' not found."
+          fi
+
+      - name: Uninstall Helm Release
+        if: steps.check-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+
+      - name: Uppercase component name
+        id: uppercase
+        run: |
+          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
+
+      - name: Launch Helm Instill Base (release)
+        run: |
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+            --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
+            --set console.image.tag=${CONSOLE_VERSION} \
+            --set tags.observability=false
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of base-api-gateway
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+
+      - name: Run ${{ inputs.component }} integration test (release)
+        env:
+          COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}
+        run: |
+          git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+      - name: Uninstall Base Helm Release
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai

--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Port-forward of base-api-gateway
         run: |
-          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=basee" -o json | jq -r '.items[0].metadata.name')
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
           kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
           while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
 

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -1,0 +1,623 @@
+name: Helm Integration Test Reusable (console)
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+
+jobs:
+  helm-integration-test-latest-linux:
+    if: inputs.target == 'latest'
+    runs-on: ubuntu-latest
+    steps:
+      # mono occupies port 8084 which conflicts with mgmt-backend
+      - name: Stop mono service
+        run: |
+          sudo kill -9 `sudo lsof -t -i:8084`
+          sudo lsof -i -P -n | grep LISTEN
+
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
+
+      - name: Start Minikube
+        run: minikube start --cpus 2 --memory 6096    
+
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file (base)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Install k6
+        run: |
+          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin    
+
+      - name: Launch Instill Base (latest)
+        run: |
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set tags.observability=false \
+            --set tags.prometheusStack=false \
+            --set apiGateway.image.tag=latest \
+            --set mgmtBackend.image.tag=latest \
+            --set console.image.tag=latest \
+            --set apiGatewayURL=http://localhost:${API_GATEWAY_PORT} \
+            --set console.serverApiGatewayURL=http://localhost:${API_GATEWAY_PORT} \
+            --set consoleURL=http://localhost:${CONSOLE_PORT}
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of base api-gateway and console
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          CONSOLE_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=console,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${CONSOLE_POD_NAME} ${CONSOLE_PORT}:${CONSOLE_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+          while ! nc -vz localhost ${CONSOLE_PORT} > /dev/null 2>&1; do sleep 1; done
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (latest)
+        run: |
+          helm install vdp charts/vdp --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set pipelineBackend.image.tag=latest \
+            --set connectorBackend.image.tag=latest \
+            --set connectorBackend.excludelocalconnector=false \
+            --set controllerVDP.image.tag=latest
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill Model (latest)
+        run: |
+          helm install model charts/model --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set modelBackend.image.tag=latest \
+            --set controllerModel.image.tag=latest \
+            --set itMode.enabled=true
+
+      - name: Run console integration test (latest)
+        run: |
+          git clone https://github.com/instill-ai/console.git
+          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
+          docker run -t --rm \
+            -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=k8s-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://localhost:${CONSOLE_PORT} \
+            -e NEXT_PUBLIC_API_GATEWAY_URL=http://localhost:${API_GATEWAY_PORT} \
+            -e NEXT_SERVER_API_GATEWAY_URL=http://localhost:${API_GATEWAY_PORT} \
+            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
+            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
+            --network host \
+            --entrypoint ./entrypoint-playwright.sh \
+            --name base-console-integration-test-latest \
+            console-playwright:latest
+
+  helm-integration-test-latest-mac:
+    if: inputs.target == 'latest'
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if Model Helm release exists
+        id: check-model-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'model'; then
+            echo "Helm release 'model' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'model' not found."
+          fi
+
+      - name: Uninstall Model Helm Release
+        if: steps.check-model-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall model --namespace instill-ai
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if VDP Helm release exists
+        id: check-vdp-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'vdp'; then
+            echo "Helm release 'vdp' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'vdp' not found."
+          fi
+
+      - name: Uninstall VDP Helm Release
+        if: steps.check-vdp-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall vdp --namespace instill-ai
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if Base Helm release exists
+        id: check-base-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'base'; then
+            echo "Helm release 'base' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'base' not found."
+          fi
+
+      - name: Uninstall Base Helm Release
+        if: steps.check-base-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+      - name: Install k6
+        run: |
+          brew install k6 
+
+      - name: Launch Instill Base (latest)
+        run: |
+          make build-latest
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set tags.observability=false \
+            --set tags.prometheusStack=false \
+            --set apiGateway.image.tag=latest \
+            --set mgmtBackend.image.tag=latest \
+            --set console.image.tag=latest \
+            --set apiGatewayURL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            --set console.serverApiGatewayURL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            --set consoleURL=http://host.docker.internal:${CONSOLE_PORT}
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of base api-gateway and console
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          CONSOLE_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=console,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${CONSOLE_POD_NAME} ${CONSOLE_PORT}:${CONSOLE_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+          while ! nc -vz localhost ${CONSOLE_PORT} > /dev/null 2>&1; do sleep 1; done      
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (latest)
+        run: |
+          helm install vdp charts/vdp --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set pipelineBackend.image.tag=latest \
+            --set connectorBackend.image.tag=latest \
+            --set connectorBackend.excludelocalconnector=false \
+            --set controllerVDP.image.tag=latest
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill Model (latest)
+        run: |
+          helm install model charts/model --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set modelBackend.image.tag=latest \
+            --set controllerModel.image.tag=latest \
+            --set itMode.enabled=true
+
+      - name: Run console integration test (latest)
+        run: |
+          git clone https://github.com/instill-ai/console.git
+          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
+          docker run -t --rm \
+            -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=k8s-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://host.docker.internal:${CONSOLE_PORT} \
+            -e NEXT_PUBLIC_API_GATEWAY_URL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            -e NEXT_SERVER_API_GATEWAY_URL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
+            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
+            --entrypoint ./entrypoint-playwright.sh \
+            --name base-console-integration-test-latest \
+            console-playwright:latest
+
+      - name: Make down base, model and vdp helm chart
+        run: |
+          helm uninstall model --namespace instill-ai
+          helm uninstall vdp --namespace instill-ai
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Make down build-latest
+        run: |
+           pkill -f "port-forward"
+           EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+  helm-integration-test-release-linux:
+    if: inputs.target == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      # mono occupies port 8084 which conflicts with mgmt-backend
+      - name: Stop mono service
+        run: |
+          sudo kill -9 `sudo lsof -t -i:8084`
+          sudo lsof -i -P -n | grep LISTEN
+
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
+
+      - name: Start Minikube
+        run: minikube start --cpus 2 --memory 6096     
+
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file (base)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Install k6
+        run: |
+          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin     
+
+      - name: Launch Instill Base (release)
+        run: |
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set tags.observability=false \
+            --set tags.prometheusStack=false \
+            --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+            --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
+            --set console.image.tag=${CONSOLE_VERSION} \
+            --set apiGatewayURL=http://localhost:${API_GATEWAY_PORT} \
+            --set console.serverApiGatewayURL=http://localhost:${API_GATEWAY_PORT} \
+            --set consoleURL=http://localhost:${CONSOLE_PORT}
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of base api-gateway and console
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          CONSOLE_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=console,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${CONSOLE_POD_NAME} ${CONSOLE_PORT}:${CONSOLE_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+          while ! nc -vz localhost ${CONSOLE_PORT} > /dev/null 2>&1; do sleep 1; done
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (release)
+        run: |
+          helm install vdp charts/vdp --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set pipelineBackend.image.tag=latest \
+            --set connectorBackend.image.tag=latest \
+            --set connectorBackend.excludelocalconnector=false \
+            --set controllerVDP.image.tag=latest
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill Model (release)
+        run: |
+          helm install model charts/model --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set modelBackend.image.tag=latest \
+            --set controllerModel.image.tag=latest \
+            --set itMode.enabled=true
+
+      - name: Run console integration test (release)
+        run: |
+          git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
+          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
+          docker run -t --rm \
+            -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=k8s-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://localhost:${CONSOLE_PORT} \
+            -e NEXT_PUBLIC_API_GATEWAY_URL=http://localhost:${API_GATEWAY_PORT} \
+            -e NEXT_SERVER_API_GATEWAY_URL=http://localhost:${API_GATEWAY_PORT} \
+            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
+            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
+            --network host \
+            --entrypoint ./entrypoint-playwright.sh \
+            --name base-console-integration-test-release \
+            console-playwright:${{ env.CONSOLE_VERSION }}
+
+  helm-integration-test-release-mac:
+    if: inputs.target == 'release'
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if Model Helm release exists
+        id: check-model-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'model'; then
+            echo "Helm release 'model' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'model' not found."
+          fi
+
+      - name: Uninstall Model Helm Release
+        if: steps.check-model-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall model --namespace instill-ai
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if VDP Helm release exists
+        id: check-vdp-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'vdp'; then
+            echo "Helm release 'vdp' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'vdp' not found."
+          fi
+
+      - name: Uninstall VDP Helm Release
+        if: steps.check-vdp-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall vdp --namespace instill-ai
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if Base Helm release exists
+        id: check-base-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'base'; then
+            echo "Helm release 'base' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'base' not found."
+          fi
+
+      - name: Uninstall Base Helm Release
+        if: steps.check-base-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Launch Instill Base (release)
+        run: |
+          make build-release
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set tags.observability=false \
+            --set tags.prometheusStack=false \
+            --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+            --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
+            --set console.image.tag=${CONSOLE_VERSION} \
+            --set apiGatewayURL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            --set console.serverApiGatewayURL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            --set consoleURL=http://host.docker.internal:${CONSOLE_PORT}
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of base api-gateway and console
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          CONSOLE_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=console,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${CONSOLE_POD_NAME} ${CONSOLE_PORT}:${CONSOLE_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+          while ! nc -vz localhost ${CONSOLE_PORT} > /dev/null 2>&1; do sleep 1; done
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (release)
+        run: |
+          helm install vdp charts/vdp --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set pipelineBackend.image.tag=latest \
+            --set connectorBackend.image.tag=latest \
+            --set connectorBackend.excludelocalconnector=false \
+            --set controllerVDP.image.tag=latest
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill Model (release)
+        run: |
+          helm install model charts/model --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set modelBackend.image.tag=latest \
+            --set controllerModel.image.tag=latest \
+            --set itMode.enabled=true
+
+      - name: Run console integration test (release)
+        run: |
+          git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
+          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
+          docker run -t --rm \
+            -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=k8s-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://host.docker.internal:${CONSOLE_PORT} \
+            -e NEXT_PUBLIC_API_GATEWAY_URL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            -e NEXT_SERVER_API_GATEWAY_URL=http://host.docker.internal:${API_GATEWAY_PORT} \
+            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
+            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
+            --entrypoint ./entrypoint-playwright.sh \
+            --name base-console-integration-test-release \
+            console-playwright:${{ env.CONSOLE_VERSION }}
+
+      - name: Make down base, model and vdp helm chart
+        run: |
+          helm uninstall model --namespace instill-ai
+          helm uninstall vdp --namespace instill-ai
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Make down build-release
+        run: |
+           pkill -f "port-forward"
+           EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v

--- a/.github/workflows/helm-integration-test-latest.yml
+++ b/.github/workflows/helm-integration-test-latest.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
       target: latest
   console:
-    uses: instill-ai/base/.github/workflows/helm-integration-test-console.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    uses: instill-ai/base/.github/workflows/helm-integration-test-console.yml@main
     with:
       target: latest    

--- a/.github/workflows/helm-integration-test-latest.yml
+++ b/.github/workflows/helm-integration-test-latest.yml
@@ -12,7 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@main
+    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
     with:
       component: ${{ matrix.component }}
       target: latest
+  console:
+    uses: instill-ai/base/.github/workflows/helm-integration-test-console.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    with:
+      target: latest    

--- a/.github/workflows/helm-integration-test-release.yml
+++ b/.github/workflows/helm-integration-test-release.yml
@@ -14,7 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@main
+    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
     with:
       component: ${{ matrix.component }}
       target: release
+  console:
+    uses: instill-ai/base/.github/workflows/helm-integration-test-console.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    with:
+      target: release    

--- a/.github/workflows/helm-integration-test-release.yml
+++ b/.github/workflows/helm-integration-test-release.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    uses: instill-ai/base/.github/workflows/helm-integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
       target: release
   console:
-    uses: instill-ai/base/.github/workflows/helm-integration-test-console.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    uses: instill-ai/base/.github/workflows/helm-integration-test-console.yml@main
     with:
       target: release    

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Make down base
         run: |
           docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
 
       - name: Launch Instill Base (latest)
         run: |
@@ -101,7 +102,14 @@ jobs:
 
       - name: Make down base
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          docker rm -f base-build-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
 
   integration-test-release-linux:
     if: inputs.target == 'release'
@@ -180,6 +188,7 @@ jobs:
       - name: Make down base
         run: |
           docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
 
       - name: Uppercase component name
         id: uppercase
@@ -203,4 +212,11 @@ jobs:
 
       - name: Make down base
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          docker rm -f base-build-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 jobs:
-  integration-test-latest:
+  integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +58,52 @@ jobs:
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
-  integration-test-release:
+  integration-test-latest-mac:
+    if: inputs.target == 'latest'      
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+      - name: Launch Instill Base (latest)
+        run: |
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Run ${{ inputs.component }} integration test (latest)
+        run: |
+          git clone https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+  integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -109,3 +154,53 @@ jobs:
           git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+  integration-test-release-mac:
+    if: inputs.target == 'release'
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+      - name: Uppercase component name
+        id: uppercase
+        run: |
+          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
+
+      - name: Launch Instill Base (release)
+        run: |
+          EDITION=local-ce:test \
+          docker compose up -d --quiet-pull
+          EDITION=local-ce:test \
+          docker compose rm -f
+
+      - name: Run ${{ inputs.component }} integration test (release)
+        env:
+          COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}
+        run: |
+          git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -113,6 +113,34 @@ jobs:
         run: |
           brew install make
 
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Make down model
+        run: |
+          docker rm -f model-build-latest >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f model-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Make down vdp
+        run: |
+          docker rm -f vdp-build-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f vdp-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
       - name: Checkout repo (base)
         uses: actions/checkout@v3
         with:
@@ -125,7 +153,14 @@ jobs:
 
       - name: Make down base
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v    
+          docker rm -f base-build-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
 
       - name: Launch Instill Base (latest)
         run: |
@@ -147,10 +182,6 @@ jobs:
         with:
           envFile: .env
 
-      - name: Make down vdp
-        run: |
-          EDITION=NULL docker compose down -v
-
       - name: Launch Instill VDP (latest)
         run: |
           COMPOSE_PROFILES=all \
@@ -170,12 +201,9 @@ jobs:
         with:
           envFile: .env
 
-      - name: Make down model
-        run: |
-          EDITION=NULL docker compose down -v
-
       - name: Launch Instill Model (latest)
         run: |
+          make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
@@ -211,6 +239,10 @@ jobs:
 
       - name: Make down vdp
         run: |
+          docker rm -f vdp-build-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f vdp-dind-latest >/dev/null 2>&1
           EDITION=NULL docker compose down -v
 
       - name: Checkout repo (model)
@@ -220,6 +252,10 @@ jobs:
 
       - name: Make down model
         run: |
+          docker rm -f model-build-latest >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f model-dind-latest >/dev/null 2>&1
           EDITION=NULL docker compose down -v
 
       - name: Checkout repo (base)
@@ -229,7 +265,14 @@ jobs:
 
       - name: Make down base
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          docker rm -f base-build-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
 
   integration-test-release-linux:
     if: inputs.target == 'release'
@@ -247,7 +290,7 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls --all --quiet)
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df --human-readable
+          df --human-readable   
 
       - name: Checkout repo (base)
         uses: actions/checkout@v3
@@ -298,6 +341,7 @@ jobs:
 
       - name: Launch Instill Model (release)
         run: |
+          make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
@@ -334,6 +378,34 @@ jobs:
         run: |
           brew install make
 
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Make down model
+        run: |
+          docker rm -f model-build-release >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f model-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Make down vdp
+        run: |
+          docker rm -f vdp-build-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f vdp-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
       - name: Checkout repo (base)
         uses: actions/checkout@v3
         with:
@@ -346,7 +418,14 @@ jobs:
 
       - name: Make down base
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          docker rm -f base-build-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
 
       - name: Launch Instill Base (release)
         run: |
@@ -365,10 +444,6 @@ jobs:
         uses: cardinalby/export-env-action@v2
         with:
           envFile: .env
-
-      - name: Make down vdp
-        run: |
-          EDITION=NULL docker compose down -v
 
       - name: Launch Instill VDP (release)
         run: |
@@ -389,12 +464,9 @@ jobs:
         with:
           envFile: .env
 
-      - name: Make down model
-        run: |
-          EDITION=NULL docker compose down -v
-
       - name: Launch Instill Model (release)
         run: |
+          make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
@@ -430,6 +502,10 @@ jobs:
 
       - name: Make down vdp
         run: |
+          docker rm -f vdp-build-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f vdp-dind-release >/dev/null 2>&1
           EDITION=NULL docker compose down -v
 
       - name: Checkout repo (model)
@@ -439,6 +515,10 @@ jobs:
 
       - name: Make down model
         run: |
+          docker rm -f model-build-release >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f model-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f model-dind-release >/dev/null 2>&1
           EDITION=NULL docker compose down -v
 
       - name: Checkout repo (base)
@@ -448,4 +528,11 @@ jobs:
 
       - name: Make down base
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          docker rm -f base-build-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 jobs:
-  integration-test-latest:
+  integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
     steps:
@@ -105,7 +105,133 @@ jobs:
             --name console-integration-test \
             console-playwright:latest
 
-  integration-test-release:
+  integration-test-latest-mac:
+    if: inputs.target == 'latest'
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file (base)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v    
+
+      - name: Launch Instill Base (latest)
+        run: |
+          CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway \
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down vdp
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Launch Instill VDP (latest)
+        run: |
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down model
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Launch Instill Model (latest)
+        run: |
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Run console integration test (latest)
+        run: |
+          git clone https://github.com/instill-ai/console.git
+          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
+          docker run -t --rm \
+            -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=local-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \
+            -e NEXT_PUBLIC_API_GATEWAY_URL=http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}  \
+            -e NEXT_SERVER_API_GATEWAY_URL=http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}  \
+            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
+            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
+            --network instill-network \
+            --entrypoint ./entrypoint-playwright.sh \
+            --name console-integration-test \
+            console-playwright:latest
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Make down vdp
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Make down model
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+  integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -151,7 +277,7 @@ jobs:
         with:
           envFile: .env
 
-      - name: Launch Instill VDP (latest)
+      - name: Launch Instill VDP (release)
         run: |
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
@@ -170,7 +296,7 @@ jobs:
         with:
           envFile: .env
 
-      - name: Launch Instill Model (latest)
+      - name: Launch Instill Model (release)
         run: |
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
@@ -199,3 +325,127 @@ jobs:
             --entrypoint ./entrypoint-playwright.sh \
             --name console-integration-test \
             console-playwright:${{ env.CONSOLE_VERSION }}
+
+  integration-test-release-mac:
+    if: inputs.target == 'release'
+    runs-on: [self-hosted,macOS,base]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file (base)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+
+      - name: Launch Instill Base (release)
+        run: |
+          CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway \
+          EDITION=local-ce:test \
+          docker compose up -d --quiet-pull
+          EDITION=local-ce:test \
+          docker compose rm -f
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down vdp
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Launch Instill VDP (release)
+        run: |
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Load .env file (model)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down model
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Launch Instill Model (release)
+        run: |
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          ITMODE_ENABLED=true \
+          TRITON_CONDA_ENV_PLATFORM=cpu \
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Run console integration test (release)
+        run: |
+          git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
+          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
+          docker run -t --rm \
+            -e NEXT_PUBLIC_API_VERSION=v1alpha \
+            -e NEXT_PUBLIC_CONSOLE_EDITION=local-ce:test \
+            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \
+            -e NEXT_PUBLIC_API_GATEWAY_URL=http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}  \
+            -e NEXT_SERVER_API_GATEWAY_URL=http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}  \
+            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
+            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
+            --network instill-network \
+            --entrypoint ./entrypoint-playwright.sh \
+            --name console-integration-test \
+            console-playwright:${{ env.CONSOLE_VERSION }}
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Make down vdp
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Checkout repo (model)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/model
+
+      - name: Make down model
+        run: |
+          EDITION=NULL docker compose down -v
+
+      - name: Checkout repo (base)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Make down base
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v

--- a/.github/workflows/integration-test-latest.yml
+++ b/.github/workflows/integration-test-latest.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
       target: latest
   console:
-    uses: instill-ai/base/.github/workflows/integration-test-console.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
+    uses: instill-ai/base/.github/workflows/integration-test-console.yml@main
     with:
       target: latest

--- a/.github/workflows/integration-test-latest.yml
+++ b/.github/workflows/integration-test-latest.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@main
+    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
     with:
       component: ${{ matrix.component }}
       target: latest
   console:
-    uses: instill-ai/base/.github/workflows/integration-test-console.yml@main
+    uses: instill-ai/base/.github/workflows/integration-test-console.yml@sarthakgupta/ins-1586-create-integration-tests-cicd-for-mac-in-base-model-and-vdp
     with:
       target: latest


### PR DESCRIPTION
Because

- We have to automate make integration-test-latest|release and helm-integration-test-latest|release for mac

This commit

- add integration-test-latest|release workflow for mac
