### PR TITLE
chore(makefile): use docker to generate DEFAULT_USER_UID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ HELM_RELEASE_NAME := base
 # check or generate uuid for user
 ifeq ($(wildcard ${SYSTEM_CONFIG_PATH}/user_uid),)
 $(shell mkdir -p ${SYSTEM_CONFIG_PATH})
-$(shell uuidgen >> ${SYSTEM_CONFIG_PATH}/user_uid)
+$(shell docker run --rm andyneff/uuidgen > ${SYSTEM_CONFIG_PATH}/user_uid)
 endif
 DEFAULT_USER_UID := $(shell cat ${SYSTEM_CONFIG_PATH}/user_uid)
 


### PR DESCRIPTION
Because

- the `uuidgen` tool is not installed in every environment

This commit

- use docker to generate `DEFAULT_USER_UID`
