### PR TITLE
ci(workflow): increase `minikube` memory

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -30,7 +30,7 @@ jobs:
           df --human-readable
 
       - name: Start Minikube
-        run: minikube start
+        run: minikube start --memory=5G
 
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -93,7 +93,7 @@ jobs:
           df --human-readable
 
       - name: Start Minikube
-        run: minikube start
+        run: minikube start --memory=5G
 
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Because

- the default `minikube` memory is only 2GB

This commit

- increase `minikube` memory to 5GB
