### PR TITLE
ci(labler): update Github labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-🗿 instill-base:
+instill base:
   - "**"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Execute the following commands to start pre-built images with all the dependencies:
 
 ```bash
-$ git clone https://github.com/instill-ai/model.git && cd model
+$ git clone https://github.com/instill-ai/base.git && cd base
 
 # Launch all services
 $ make all


### PR DESCRIPTION
Because

- the labeler with emoji can not work with some tools

This commit

- update Github labeler
- fix typo in `README.md`
