### PR TITLE
ci(workflow): update GA workflow triggering event

### DIFF
--- a/.github/workflows/helm-integration-test-release.yml
+++ b/.github/workflows/helm-integration-test-release.yml
@@ -2,6 +2,11 @@ name: Helm Integration Test (release)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - release-please--branches--main
+    tags:
+      - v*
   
 jobs:
   backend:

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -2,6 +2,11 @@ name: Integration Test (release)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - release-please--branches--main
+    tags:
+      - v*
 
 jobs:
   backend:

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -2,10 +2,11 @@ name: Make All
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
-      - main
+      - release-please--branches--main
+    tags:
+      - v*
 
 jobs:
   make-all:


### PR DESCRIPTION
Because

- we only need to run release related workflow in branch `release-please--branches--main` and tags event

This commit

- update GA workflow triggering event
