### PR TITLE
ci(workflow): update latest tag workflow trigger on push to main branch

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -75,7 +75,7 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   helm-integration-test-latest-mac:
-    if: inputs.target == 'latest'
+    if: inputs.target == 'latest' && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true  
     runs-on: [self-hosted,macOS,base]
     steps:
       - name: Set up environment

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -127,7 +127,7 @@ jobs:
             console-playwright:latest
 
   helm-integration-test-latest-mac:
-    if: inputs.target == 'latest'
+    if: inputs.target == 'latest' && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true
     runs-on: [self-hosted,macOS,base]
     steps:
       - name: Set up environment

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -59,7 +59,7 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   integration-test-latest-mac:
-    if: inputs.target == 'latest'      
+    if: inputs.target == 'latest' && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true     
     runs-on: [self-hosted,macOS,base]
     steps:
       - name: Set up environment

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -106,7 +106,7 @@ jobs:
             console-playwright:latest
 
   integration-test-latest-mac:
-    if: inputs.target == 'latest'
+    if: inputs.target == 'latest' && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true
     runs-on: [self-hosted,macOS,base]
     steps:
       - name: Set up environment


### PR DESCRIPTION
Because

- We have to trigger latest tag workflow run on macOS post merge in main for security concern

This commit

- update latest tag workflow trigger on push to main branch
