### PR TITLE
ci(release-please): update version in README automatically

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -25,6 +25,8 @@ jobs:
           config-file: release-please/config.json
           manifest-file: release-please/manifest.json
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
+          extra-files: |
+            README.md
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
         with:

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ Execute the following commands to start pre-built images with all the dependenci
 
 **The stable release version**
 
+<!-- x-release-please-start-version -->
 ```bash
 $ git clone -b v0.3.0-alpha https://github.com/instill-ai/base.git && cd base
 
 # Launch all services
 $ make all
 ```
+<!-- x-release-please-end -->
 
 **The latest version for development**
 


### PR DESCRIPTION
Because

- we need to update the version tag in `README.md` automatically

This commit

- update version in `README.md` automatically by release-please
