### PR TITLE
ci(Makefile): tinker uuidgen and shell cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ all:			## Launch all services with their up-to-date release version
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
 	@make build-latest
-	@[ ! -f "$(shell eval echo ${SYSTEM_CONFIG_PATH})/user_uid" ] && mkdir -p $(shell eval echo ${SYSTEM_CONFIG_PATH}) && docker run --rm ${CONTAINER_COMPOSE_IMAGE_NAME}:release uuidgen > $(shell eval echo ${SYSTEM_CONFIG_PATH})/user_uid || true
+	@[ ! -f "$(shell eval echo ${SYSTEM_CONFIG_PATH})/user_uid" ] && mkdir -p $(shell eval echo ${SYSTEM_CONFIG_PATH}) && docker run --rm ${CONTAINER_COMPOSE_IMAGE_NAME}:latest uuidgen > $(shell eval echo ${SYSTEM_CONFIG_PATH})/user_uid || true
 	@COMPOSE_PROFILES=$(PROFILE) EDITION=$${EDITION:=local-ce:latest} DEFAULT_USER_UID=$(shell cat $(shell eval echo ${SYSTEM_CONFIG_PATH})/user_uid) docker compose ${COMPOSE_FILES} -f docker-compose.latest.yml up -d --quiet-pull
 
 .PHONY: logs
@@ -101,7 +101,7 @@ down:			## Stop all services and remove all service containers and volumes
 				"; \
 		fi \
 	fi
-	@EDITION= DEFAULT_USER_UID=$(cat $(shell eval echo ${SYSTEM_CONFIG_PATH})/user_uid) docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+	@EDITION= DEFAULT_USER_UID=$(shell cat $(shell eval echo ${SYSTEM_CONFIG_PATH})/user_uid) docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
 
 .PHONY: images
 images:			## List all container images


### PR DESCRIPTION
Because

- `make latest` uses a wrong tag for the dind compose image, causing `uuidgen` failed to run

This commit

- fix the wrong tag
- fix the missing `shell` for Makefile shell command
