### PR TITLE
ci(workflow): set time limit to workflow run

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -14,7 +14,11 @@ jobs:
   helm-integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -77,7 +81,11 @@ jobs:
   helm-integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 10
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       - name: Set up environment
         run: |
           brew install helm
@@ -150,7 +158,11 @@ jobs:
   helm-integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -220,7 +232,11 @@ jobs:
   helm-integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       - name: Set up environment
         run: |
           brew install helm

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -11,7 +11,11 @@ jobs:
   helm-integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -129,7 +133,11 @@ jobs:
   helm-integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       - name: Set up environment
         run: |
           brew install make
@@ -318,7 +326,11 @@ jobs:
   helm-integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -436,7 +448,11 @@ jobs:
   helm-integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       - name: Set up environment
         run: |
           brew install make

--- a/.github/workflows/helm-integration-test-release.yml
+++ b/.github/workflows/helm-integration-test-release.yml
@@ -2,11 +2,6 @@ name: Helm Integration Test (release)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   backend:

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -14,7 +14,11 @@ jobs:
   integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -61,7 +65,15 @@ jobs:
   integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 10
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
+      - name: remove existing docker container
+        run: |
+          docker rm -f $(docker ps -a -q)
+
       - name: Set up environment
         run: |
           brew install make
@@ -114,7 +126,11 @@ jobs:
   integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -166,7 +182,15 @@ jobs:
   integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 10
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
+      - name: remove existing docker container
+        run: |
+          docker rm -f $(docker ps -a -q)  
+
       - name: Set up environment
         run: |
           brew install make

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -11,7 +11,11 @@ jobs:
   integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -117,7 +121,15 @@ jobs:
   integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
+      - name: remove existing docker container
+        run: |
+          docker rm -f $(docker ps -a -q)  
+
       - name: Set up environment
         run: |
           brew install make
@@ -286,7 +298,11 @@ jobs:
   integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -391,7 +407,15 @@ jobs:
   integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
+      - name: remove existing docker container
+        run: |
+          docker rm -f $(docker ps -a -q)  
+
       - name: Set up environment
         run: |
           brew install make

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -2,11 +2,6 @@ name: Integration Test (release)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   backend:

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -2,11 +2,6 @@ name: Make All
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   make-all:


### PR DESCRIPTION
Because

- We have to create logic to cancel previous workflow if new one it triggered
- We have to set time limit for each workflow run

This commit

- set time limit to workflow run
