### PR TITLE
chore(ray): add ray platform env variable

### DIFF
--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -111,7 +111,8 @@ jobs:
             --set edition=k8s-ce:test \
             --set modelBackend.image.tag=latest \
             --set controllerModel.image.tag=latest \
-            --set itMode.enabled=true
+            --set itMode.enabled=true \
+            --set ray.platform=cpu
 
       - name: Run console integration test (latest)
         run: |
@@ -288,7 +289,8 @@ jobs:
             --set edition=k8s-ce:test \
             --set modelBackend.image.tag=latest \
             --set controllerModel.image.tag=latest \
-            --set itMode.enabled=true
+            --set itMode.enabled=true \
+            --set ray.platform=arm
 
       - name: Run console integration test (latest)
         run: |
@@ -426,7 +428,8 @@ jobs:
             --set edition=k8s-ce:test \
             --set modelBackend.image.tag=latest \
             --set controllerModel.image.tag=latest \
-            --set itMode.enabled=true
+            --set itMode.enabled=true \
+            --set ray.platform=cpu
 
       - name: Run console integration test (release)
         run: |
@@ -603,7 +606,8 @@ jobs:
             --set edition=k8s-ce:test \
             --set modelBackend.image.tag=latest \
             --set controllerModel.image.tag=latest \
-            --set itMode.enabled=true
+            --set itMode.enabled=true \
+            --set ray.platform=arm
 
       - name: Run console integration test (release)
         run: |

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -92,11 +92,13 @@ jobs:
         run: |
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
@@ -227,11 +229,13 @@ jobs:
           make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=arm \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=arm \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
@@ -378,11 +382,13 @@ jobs:
           make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
@@ -511,11 +517,13 @@ jobs:
           make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=arm \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=arm \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f

--- a/Makefile
+++ b/Makefile
@@ -69,17 +69,19 @@ all:			## Launch all services with their up-to-date release version
 	@if [ "${PROJECT}" = "all" ] || [ "${PROJECT}" = "model" ]; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
+		export RAY_PLATFORM=$(shell uname -p) && \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
 			-e BUILD=${BUILD} \
 			-e BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} \
+			-e RAY_PLATFORM=$${RAY_PLATFORM} \
 			--name ${CONTAINER_COMPOSE_NAME}-release \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_CORE_VERSION} /bin/sh -c " \
 				cp /instill-ai/model/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/model/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
-				/bin/sh -c 'cd /instill-ai/model && make all BUILD=${BUILD} EDITION=$${EDITION:=local-ce} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH}' && \
+				/bin/sh -c 'cd /instill-ai/model && make all BUILD=${BUILD} EDITION=$${EDITION:=local-ce} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} RAY_PLATFORM=$${RAY_PLATFORM}' && \
 				/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}; \
 	fi
@@ -113,6 +115,7 @@ latest:			## Lunch all dependent services with their latest codebase
 	@if [ "${PROJECT}" = "all" ] || [ "${PROJECT}" = "model" ]; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
+		export RAY_PLATFORM=$(shell uname -p) && \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
@@ -120,11 +123,12 @@ latest:			## Lunch all dependent services with their latest codebase
 			-e BUILD=${BUILD} \
 			-e PROFILE=${PROFILE} \
 			-e BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} \
+			-e RAY_PLATFORM=$${RAY_PLATFORM} \
 			--name ${CONTAINER_COMPOSE_NAME}-latest \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 				cp /instill-ai/model/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/model/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
-				/bin/sh -c 'cd /instill-ai/model && make latest BUILD=${BUILD} PROFILE=$${PROFILE} EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH}' && \
+				/bin/sh -c 'cd /instill-ai/model && make latest BUILD=${BUILD} PROFILE=$${PROFILE} EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} RAY_PLATFORM=$${RAY_PLATFORM}' && \
 				/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}; \
 	fi
@@ -335,15 +339,16 @@ console-integration-test-latest:			## Run console integration test on the latest
 			/bin/sh -c 'cd /instill-ai/vdp && COMPOSE_PROFILES=all EDITION=local-ce:test docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
-	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
+	@export TMP_CONFIG_DIR=$(shell mktemp -d) && export RAY_PLATFORM=$(shell uname -p) && docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
+		-e RAY_PLATFORM:$${RAY_PLATFORM} \
 		--name ${CONTAINER_COMPOSE_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 			cp /instill-ai/model/.env $${TMP_CONFIG_DIR}/.env && \
 			cp /instill-ai/model/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 			/bin/sh -c 'cd /instill-ai/model && make build-latest BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
-			/bin/sh -c 'cd /instill-ai/model && COMPOSE_PROFILES=all EDITION=local-ce:test ITMODE_ENABLED=true TRITON_CONDA_ENV_PLATFORM=cpu docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
+			/bin/sh -c 'cd /instill-ai/model && COMPOSE_PROFILES=all EDITION=local-ce:test ITMODE_ENABLED=true TRITON_CONDA_ENV_PLATFORM=cpu RAY_PLATFORM=$${RAY_PLATFORM} docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
 	@docker run --rm \
@@ -374,15 +379,16 @@ console-integration-test-release:			## Run console integration test on the relea
 			/bin/sh -c 'cd /instill-ai/vdp && COMPOSE_PROFILES=all EDITION=local-ce:test docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
-	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
+	@export TMP_CONFIG_DIR=$(shell mktemp -d) && export RAY_PLATFORM=$(shell uname -p) && docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
+		-e RAY_PLATFORM:$${RAY_PLATFORM} \
 		--name ${CONTAINER_COMPOSE_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 			cp /instill-ai/model/.env $${TMP_CONFIG_DIR}/.env && \
 			cp /instill-ai/model/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 			/bin/sh -c 'cd /instill-ai/model && make build-latest BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
-			/bin/sh -c 'cd /instill-ai/model && COMPOSE_PROFILES=all EDITION=local-ce:test ITMODE_ENABLED=true TRITON_CONDA_ENV_PLATFORM=cpu docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
+			/bin/sh -c 'cd /instill-ai/model && COMPOSE_PROFILES=all EDITION=local-ce:test ITMODE_ENABLED=true TRITON_CONDA_ENV_PLATFORM=cpu RAY_PLATFORM=$${RAY_PLATFORM} docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
 	@docker run --rm \
@@ -451,10 +457,11 @@ endif
 					--set controllerVDP.image.tag=latest' \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
-	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
+	@export TMP_CONFIG_DIR=$(shell mktemp -d) && export RAY_PLATFORM=$(shell uname -p) && docker run --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
+		-e RAY_PLATFORM:$${RAY_PLATFORM} \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_CONSOLE_INTEGRATION_TEST_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
@@ -467,6 +474,7 @@ endif
 						--set modelBackend.image.tag=latest \
 						--set controllerModel.image.tag=latest \
 						--set itMode.enabled=true' \
+						--set ray.platform=$${RAY_PLATFORM} \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
 ifeq ($(UNAME_S),Darwin)
@@ -554,10 +562,11 @@ endif
 					--set controllerVDP.image.tag=latest' \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
-	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
+	@export TMP_CONFIG_DIR=$(shell mktemp -d) && export RAY_PLATFORM=$(shell uname -p) && docker run --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
+		-e RAY_PLATFORM:$${RAY_PLATFORM} \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_CONSOLE_INTEGRATION_TEST_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
@@ -570,6 +579,7 @@ endif
 						--set modelBackend.image.tag=latest \
 						--set controllerModel.image.tag=latest \
 						--set itMode.enabled=true' \
+						--set ray.platform=$${RAY_PLATFORM} \
 			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
 ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
Because

- support launching `ray` server with correct platform suffix

This commit

- add `RAY_PLATFORM` env variable
