### PR TITLE
chore(helm): increase Ingress timeout

### DIFF
--- a/charts/core/templates/api-gateway/ingress.yaml
+++ b/charts/core/templates/api-gateway/ingress.yaml
@@ -8,7 +8,7 @@ kind: BackendConfig
 metadata:
   name: core-backend-config
 spec:
-  timeoutSec: 60
+  timeoutSec: 300
 {{- else }}
 {{- $_ := set . "rootPath" "/" -}}
 {{- end }}


### PR DESCRIPTION
Because

- the Ingress timeout is too short, the pipeline trigger will timeout

This commit

- increase Ingress timeout to 300s
