### PR TITLE
chore(helm): add rolling update strategy

### DIFF
--- a/charts/core/templates/api-gateway/deployment.yaml
+++ b/charts/core/templates/api-gateway/deployment.yaml
@@ -10,7 +10,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.apiGateway.autoscaling.enabled }}

--- a/charts/core/templates/console/deployment.yaml
+++ b/charts/core/templates/console/deployment.yaml
@@ -11,7 +11,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.console.autoscaling.enabled }}

--- a/charts/core/templates/mgmt-backend/deployment.yaml
+++ b/charts/core/templates/mgmt-backend/deployment.yaml
@@ -10,7 +10,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.mgmtBackend.autoscaling.enabled }}

--- a/charts/core/templates/openfga/deployment.yaml
+++ b/charts/core/templates/openfga/deployment.yaml
@@ -10,7 +10,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.openfga.autoscaling.enabled }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -8,6 +8,9 @@ fullnameOverride: ""
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
   type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
 # -- Logging level: debug, info, warning, error or fatal
 logLevel: info
 # -- Enable development mode


### PR DESCRIPTION
Because

- we need to add the maxSurge and maxUnavailable values into the deployment 

This commit

- add rolling update strategy
