### PR TITLE
ci(Makefile): unify Instill Core instance host

### DIFF
--- a/.env
+++ b/.env
@@ -44,6 +44,9 @@ INSTILL_VDP_VERSION=0.18.0-alpha
 # Instill Model
 INSTILL_MODEL_VERSION=0.5.0-alpha
 
+# Instill Core isntance host
+INSTILL_CORE_HOST=localhost
+
 # api-gateway
 API_GATEWAY_IMAGE=instill/api-gateway
 API_GATEWAY_VERSION=0.6.0-alpha
@@ -77,8 +80,6 @@ CONSOLE_IMAGE=instill/console
 CONSOLE_VERSION=0.32.0-alpha
 CONSOLE_HOST=console
 CONSOLE_PORT=3000
-CONSOLE_URL_HOST=localhost
-CONSOLE_PUBLIC_API_GATEWAY_HOST=localhost
 
 # PostgreSQL
 POSTGRESQL_IMAGE=postgres

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: Launch Instill Core (latest)
         run: |
-          CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
@@ -187,7 +186,6 @@ jobs:
 
       - name: Launch Instill Core (latest)
         run: |
-          CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
@@ -342,7 +340,6 @@ jobs:
 
       - name: Launch Instill Core (release)
         run: |
-          CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway \
           EDITION=local-ce:test \
           docker compose up -d --quiet-pull
           EDITION=local-ce:test \
@@ -477,7 +474,6 @@ jobs:
 
       - name: Launch Instill Core (release)
         run: |
-          CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway \
           EDITION=local-ce:test \
           docker compose up -d --quiet-pull
           EDITION=local-ce:test \

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ endif
 
 .PHONY: console-integration-test-latest
 console-integration-test-latest:			## Run console integration test on the latest Instill Core
-	@make latest PROJECT=core EDITION=local-ce:test CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway
+	@make latest PROJECT=core EDITION=local-ce:test
 	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
@@ -370,7 +370,7 @@ console-integration-test-latest:			## Run console integration test on the latest
 
 .PHONY: console-integration-test-release
 console-integration-test-release:			## Run console integration test on the release Instill Core
-	@make all PROJECT=core EDITION=local-ce:test CONSOLE_PUBLIC_API_GATEWAY_HOST=api-gateway
+	@make all PROJECT=core EDITION=local-ce:test
 	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,8 +103,8 @@ services:
       NEXT_PUBLIC_API_VERSION: v1alpha
       NEXT_PUBLIC_USAGE_COLLECTION_ENABLED: ${USAGE_ENABLED}
       NEXT_PUBLIC_CONSOLE_EDITION: ${EDITION}
-      NEXT_PUBLIC_CONSOLE_BASE_URL: http://${CONSOLE_URL_HOST}:${CONSOLE_PORT}
-      NEXT_PUBLIC_API_GATEWAY_URL: http://${CONSOLE_PUBLIC_API_GATEWAY_HOST}:${API_GATEWAY_PORT}
+      NEXT_PUBLIC_CONSOLE_BASE_URL: http://${INSTILL_CORE_HOST}:${CONSOLE_PORT}
+      NEXT_PUBLIC_API_GATEWAY_URL: http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT}
       NEXT_SERVER_API_GATEWAY_URL: http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}
       NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME: instill-ai-user
       NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION: "false"
@@ -230,9 +230,8 @@ services:
     container_name: ${OPENFGA_HOST}_createdb
     command: bash -c 'createdb -h ${POSTGRESQL_HOST} -U postgres -w openfga || true'
     environment:
-       PGPASSWORD: password
-    
-  
+      PGPASSWORD: password
+
   openfga_migrate:
     depends_on:
       openfga_createdb:
@@ -243,7 +242,7 @@ services:
     environment:
       - OPENFGA_DATASTORE_ENGINE=postgres
       - OPENFGA_DATASTORE_URI=postgres://postgres:password@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/openfga?sslmode=disable
-      
+
   openfga:
     depends_on:
       openfga_migrate:
@@ -255,4 +254,3 @@ services:
       - OPENFGA_DATASTORE_ENGINE=postgres
       - OPENFGA_DATASTORE_URI=postgres://postgres:password@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/openfga?sslmode=disable
     command: run
-


### PR DESCRIPTION
Because

- both env variables `CONSOLE_URL_HOST` and `CONSOLE_PUBLIC_API_GATEWAY_HOST` reflect to the Instill Core instance host, we can actually merge them into one `INSTILL_CORE_HOST` for the self-host users to deploy with custom hostname.

This commit

- replace the env variables `CONSOLE_URL_HOST` and `CONSOLE_PUBLIC_API_GATEWAY_HOST` with `INSTILL_CORE_HOST`
