### PR TITLE
chore(ci): disable integration test on MacOS

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -79,7 +79,9 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   helm-integration-test-latest-mac:
-    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 10
     steps:
@@ -230,7 +232,9 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   helm-integration-test-release-mac:
-    if: inputs.target == 'release'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 20
     steps:

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -133,7 +133,9 @@ jobs:
             console-playwright:latest
 
   helm-integration-test-latest-mac:
-    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 20
     steps:
@@ -452,7 +454,9 @@ jobs:
             console-playwright:${{ env.CONSOLE_VERSION }}
 
   helm-integration-test-release-mac:
-    if: inputs.target == 'release'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 30
     steps:

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -63,7 +63,9 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   integration-test-latest-mac:
-    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 10
     steps:
@@ -180,7 +182,9 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   integration-test-release-mac:
-    if: inputs.target == 'release'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 10
     steps:

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -121,7 +121,9 @@ jobs:
             console-playwright:latest
 
   integration-test-latest-mac:
-    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 20
     steps:
@@ -411,7 +413,9 @@ jobs:
             console-playwright:${{ env.CONSOLE_VERSION }}
 
   integration-test-release-mac:
-    if: inputs.target == 'release'
+    if: false
+    # disable the mac test temporary 
+    # if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, core]
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Because

- The tests running on MacOS are not robust in current CI environment, we decided to disable it temporally and will come back to this problem soon. 

This commit

- disable integration test on MacOS
