### PR TITLE
chore(helm): update security context for api-gateway

### DIFF
--- a/charts/core/templates/api-gateway/deployment.yaml
+++ b/charts/core/templates/api-gateway/deployment.yaml
@@ -36,8 +36,8 @@ spec:
         {{- end }}
     spec:
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 65534
+        runAsGroup: 65534
       {{- if .Values.apiGateway.serviceAccountName }}
       serviceAccountName: {{ .Values.apiGateway.serviceAccountName }}
       {{- end }}


### PR DESCRIPTION
Because

- api-gateway now use alpine image and `nobody:nogroup` as default user

This commit

- update security context `runAs` user and group
