### PR TITLE
docs(openapi): create action to update API version in protobufs

### DIFF
--- a/.github/workflows/sync-version-with-api-docs.yml
+++ b/.github/workflows/sync-version-with-api-docs.yml
@@ -1,0 +1,38 @@
+# This workflow will open a PR in https://github.com/instill-ai/protobufs
+# updating the API version in the OpenAPI specifications.
+
+name: Sync release version with OpenAPI docs
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  update-api-docs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout protobufs repository
+      uses: actions/checkout@v4
+      with:
+        repository: instill-ai/protobufs
+        token: ${{ secrets.botGitHubToken }}
+    - name: Modify the API version in OpenAPI configuration
+      run: |
+        # On release triggers, GITHUB_REF_NAME is the release name (e.g.
+        # 'v0.10.0-beta')
+        sed -i "s/version: \".*\"/version: \"${GITHUB_REF_NAME}\"/" common/openapi/v1beta/api_info.conf
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.botGitHubToken }}
+        commit-message: 'chore: update API version'
+        title: 'chore: update API version'
+        body: Sync API version with latest Core release
+        branch: chore/update-api-version
+        base: main
+        draft: false


### PR DESCRIPTION
Because

- API version should match latest release name in `instill-ai/core`.
- We rely on documentation and manual actions to keep these repos in sync.

This commit

- Adds a GitHub action that creates a PR in the `protobufs` repo modifying the
  API version.

## Notes 🗒️ 

I forked [core](https://github.com/jvallesm/instill-core) and [protobufs](https://github.com/jvallesm/instill-protobufs) repos to test this action (setting up my own API tokens).

### New release in `core`

![CleanShot 2024-01-19 at 12 01 05](https://github.com/instill-ai/core/assets/3977183/448c3283-0f62-41ca-b4b2-7cfcf4ef4797)
![CleanShot 2024-01-19 at 12 01 15](https://github.com/instill-ai/core/assets/3977183/8f0c7c2b-d3ba-43f7-ac71-70663dae3113)

### ⏭️ New PR in `protobufs`

See PR [here](https://github.com/jvallesm/instill-protobufs/pull/4).

![CleanShot 2024-01-19 at 12 03 08](https://github.com/instill-ai/core/assets/3977183/741471ea-c948-43c7-8991-89c3208e9f75)

**Note:** The PR and branch names omit intentionally the release name. This makes the PR action to update the PR in `protobufs` if several releases pile up.

### `TODO`: check OpenAPI file generation

The PR in the forked `protobufs` repo doesn't trigger the OpenAPI generation workflow. As far as I understand we aren't using the `GITHUB_TOKEN` variable so the workflow should be triggered. Perhaps it's the config in my forked repo. Let's check in the next release, if the files aren't generated we can open a PR and make generation part of this action, adding a `buf` step and a `make openapi` command.