### PR TITLE
ci(core): fix make build-latest PROFILE

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ $ make latest PROFILE=all
 The env variable `PROFILE` is intended to specify which service component you want to develop on
 - `all`
 
-  When you set `PROFILE=all`, the whole `Instill Core` stack will be launched, meaning you want to test the system as a whole
+  When you set `PROFILE=all`, the whole `Instill Core` stack will be launched, meaning you want to test the system as a whole.
 
 - `{service}`
 

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -44,10 +44,11 @@ jobs:
           docker ps -a
           sleep 60
 
-      - name: Probe to core (influxdb, temporal and console) healthcheck endpoint
+      - name: Probe to core (influxdb, temporal, etcd, and console) healthcheck endpoint
         run: |
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8086/health
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8088/health
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3379/health
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3000
 
       - name: Probe to core services healthcheck endpoint

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           sudo kill -9 `sudo lsof -t -i:8084`
           sudo lsof -i -P -n | grep LISTEN
-    
+
       - name: Free disk space
         run: |
           df --human-readable
@@ -37,21 +37,23 @@ jobs:
 
       - name: Install k6
         run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin  
+          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (latest)
-        run: make latest PROFILE=exclude-console PROJECT=core EDITION=local-ce:test
+        run: |
+          make latest PROJECT=core EDITION=local-ce:test
 
       - name: List all docker containers
         run: |
           docker ps -a
           sleep 30
 
-      - name: Curl to core (influxdb, temporal, console and etcd) healthcheck endpoint
+      - name: Curl to core (influxdb, temporal, etcd, and console) healthcheck endpoint
         run: |
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8086/health
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8088/health
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3379/health
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3000
 
       - name: Curl to core services healthcheck endpoint
         run: |

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ all:			## Launch all services with their up-to-date release version
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
-			-e BUILD=${BUILD} \
 			-e BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} \
 			--name ${CONTAINER_COMPOSE_NAME}-release \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_CORE_VERSION} /bin/sh -c " \
@@ -80,7 +79,6 @@ all:			## Launch all services with their up-to-date release version
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
-			-e BUILD=${BUILD} \
 			-e BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} \
 			--name ${CONTAINER_COMPOSE_NAME}-release \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_CORE_VERSION} /bin/sh -c " \
@@ -93,7 +91,7 @@ all:			## Launch all services with their up-to-date release version
 
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
-	@make build-latest
+	@make build-latest PROFILE=${PROFILE}
 	@if [ ! -f "$$(echo ${SYSTEM_CONFIG_PATH}/user_uid)" ]; then \
 		mkdir -p ${SYSTEM_CONFIG_PATH} && \
 		docker run --rm --name uuidgen ${CONTAINER_COMPOSE_IMAGE_NAME}:latest uuidgen > ${SYSTEM_CONFIG_PATH}/user_uid; \
@@ -106,14 +104,12 @@ latest:			## Lunch all dependent services with their latest codebase
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
-			-e BUILD=${BUILD} \
-			-e PROFILE=${PROFILE} \
 			-e BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} \
 			--name ${CONTAINER_COMPOSE_NAME}-latest \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 				cp /instill-ai/vdp/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/vdp/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
-				/bin/sh -c 'cd /instill-ai/vdp && make latest BUILD=${BUILD} PROFILE=$${PROFILE} EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH}' && \
+				/bin/sh -c 'cd /instill-ai/vdp && make latest PROFILE=${PROFILE} EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH}' && \
 				/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}; \
 	fi
@@ -124,14 +120,12 @@ latest:			## Lunch all dependent services with their latest codebase
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
-			-e BUILD=${BUILD} \
-			-e PROFILE=${PROFILE} \
 			-e BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} \
 			--name ${CONTAINER_COMPOSE_NAME}-latest \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 				cp /instill-ai/model/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/model/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
-				/bin/sh -c 'cd /instill-ai/model && make latest BUILD=${BUILD} PROFILE=$${PROFILE} EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH}' && \
+				/bin/sh -c 'cd /instill-ai/model && make latest PROFILE=${PROFILE} EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH}' && \
 				/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}; \
 	fi
@@ -219,7 +213,7 @@ build-latest:				## Build latest images for all Instill Core components
 			API_GATEWAY_VERSION=latest \
 			MGMT_BACKEND_VERSION=latest \
 			CONSOLE_VERSION=latest \
-			docker compose -f docker-compose.build.yml build --progress plain \
+			COMPOSE_PROFILES=${PROFILE} docker compose -f docker-compose.build.yml build --progress plain \
 		"
 
 .PHONY: build-release
@@ -250,7 +244,7 @@ build-release:				## Build release images for all Instill Core components
 
 .PHONY: integration-test-latest
 integration-test-latest:			## Run integration test on the latest Instill Core
-	@make latest BUILD=true PROJECT=core EDITION=local-ce:test
+	@make latest PROJECT=core EDITION=local-ce:test
 	@docker run --rm \
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -2,6 +2,13 @@ version: "3.9"
 
 services:
   api_gateway:
+    profiles:
+      - all
+      - exclude-mgmt
+      - exclude-console
+      - exclude-pipeline
+      - exclude-model
+      - exclude-controller-model
     image: ${API_GATEWAY_IMAGE}:${API_GATEWAY_VERSION}
     build:
       context: ./${API_GATEWAY_HOST}
@@ -10,16 +17,15 @@ services:
         GOLANG_VERSION: 1.21.3
         ALPINE_VERSION: 3.18
         KRAKEND_CE_VERSION: ${KRAKEND_CE_VERSION}
-    profiles:
-      - all
-      - exclude-console
-      - exclude-pipeline
-      - exclude-controller-vdp
-      - exclude-model
-      - exclude-controller-model
-      - exclude-mgmt
 
   mgmt_backend:
+    profiles:
+      - all
+      - exclude-api-gateway
+      - exclude-console
+      - exclude-pipeline
+      - exclude-model
+      - exclude-controller-model
     image: ${MGMT_BACKEND_IMAGE}:${MGMT_BACKEND_VERSION}
     build:
       context: ./${MGMT_BACKEND_HOST}
@@ -27,41 +33,30 @@ services:
         SERVICE_NAME: ${MGMT_BACKEND_HOST}
         GOLANG_VERSION: ${GOLANG_VERSION}
         K6_VERSION: ${K6_VERSION}
+
+  console:
     profiles:
       - all
       - exclude-api-gateway
-      - exclude-console
+      - exclude-mgmt
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
-
-  console:
     image: ${CONSOLE_IMAGE}:${CONSOLE_VERSION}
     build:
       context: ./${CONSOLE_HOST}
+
+  console_playwright:
     profiles:
       - all
       - exclude-api-gateway
+      - exclude-mgmt
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
-      - exclude-mgmt
-
-  console_playwright:
     image: ${CONSOLE_IMAGE}-playwright:${CONSOLE_VERSION}
     build:
       context: ./${CONSOLE_HOST}
       dockerfile: Dockerfile.playwright
       args:
         TEST_USER: "root"
-    profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-console
-      - exclude-pipeline
-      - exclude-controller-vdp
-      - exclude-model
-      - exclude-controller-model
-      - exclude-mgmt

--- a/docker-compose.latest.yml
+++ b/docker-compose.latest.yml
@@ -7,7 +7,6 @@ services:
       - exclude-mgmt
       - exclude-console
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
     image: ${API_GATEWAY_IMAGE}:latest
@@ -20,7 +19,6 @@ services:
       - exclude-api-gateway
       - exclude-console
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
     image: ${MGMT_BACKEND_IMAGE}:latest
@@ -31,7 +29,6 @@ services:
       - exclude-api-gateway
       - exclude-console
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
     image: ${MGMT_BACKEND_IMAGE}:latest
@@ -42,7 +39,6 @@ services:
       - exclude-api-gateway
       - exclude-console
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
     image: ${MGMT_BACKEND_IMAGE}:latest
@@ -52,14 +48,13 @@ services:
     ports:
       - ${MGMT_BACKEND_PRIVATEPORT}:${MGMT_BACKEND_PRIVATEPORT}
       - ${MGMT_BACKEND_PUBLICPORT}:${MGMT_BACKEND_PUBLICPORT}
-  
+
   mgmt_backend_worker:
     profiles:
       - all
       - exclude-api-gateway
       - exclude-console
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
     image: ${MGMT_BACKEND_IMAGE}:latest
@@ -73,7 +68,6 @@ services:
       - exclude-api-gateway
       - exclude-mgmt
       - exclude-pipeline
-      - exclude-controller-vdp
       - exclude-model
       - exclude-controller-model
     image: ${CONSOLE_IMAGE}:latest


### PR DESCRIPTION
Because

- the `profile` in Docker Compose is used to launch or build components when `make latest` and `make build-latest`

This commit

- fix the logic
