### PR TITLE
ci(test): fix integration-test-console

### DIFF
--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Launch Instill Core (latest)
         run: |
+          INSTILL_CORE_HOST=api-gateway \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
@@ -344,6 +345,7 @@ jobs:
 
       - name: Launch Instill Core (release)
         run: |
+          INSTILL_CORE_HOST=api-gateway \
           EDITION=local-ce:test \
           docker compose up -d --quiet-pull
           EDITION=local-ce:test \

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ endif
 
 .PHONY: console-integration-test-latest
 console-integration-test-latest:			## Run console integration test on the latest Instill Core
-	@make latest PROJECT=core EDITION=local-ce:test
+	@make latest PROJECT=core EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
 	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
@@ -365,7 +365,7 @@ console-integration-test-latest:			## Run console integration test on the latest
 
 .PHONY: console-integration-test-release
 console-integration-test-release:			## Run console integration test on the release Instill Core
-	@make all PROJECT=core EDITION=local-ce:test
+	@make all PROJECT=core EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
 	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \


### PR DESCRIPTION
Because

- The console integration-test is broken

This commit

- Fix integration-test-console
