### PR TITLE
fix(openapi): Fix protobufs PR name

### DIFF
--- a/.github/workflows/sync-version-with-api-docs.yml
+++ b/.github/workflows/sync-version-with-api-docs.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         token: ${{ secrets.botGitHubToken }}
         commit-message: 'chore: update API version'
-        title: 'chore: update API version'
+        title: 'docs(openapi): Update API version'
         body: Sync API version with latest Core release
         branch: chore/update-api-version
         base: main


### PR DESCRIPTION
Because

- Version sync workflow [worked](https://github.com/instill-ai/protobufs/pull/260/commits) in the last release 🎉 However, the PR name didn't pass the linter action.

This commit

- Modifies the PR name in the protobufs action so next PRs will have a 🟢 CI.
