### PR TITLE
ci(workflows): use latest tag for ray

### DIFF
--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -385,13 +385,13 @@ jobs:
           make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
-          RAY_RELEASE_TAG=${RAY_SERVER_VERSION} \
+          RAY_LATEST_TAG=latest \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
-          RAY_RELEASE_TAG=${RAY_SERVER_VERSION} \
+          RAY_LATEST_TAG=latest \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
@@ -522,13 +522,13 @@ jobs:
           make build-latest
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
-          RAY_RELEASE_TAG=${RAY_SERVER_VERSION} \
+          RAY_LATEST_TAG=latest \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
-          RAY_RELEASE_TAG=${RAY_SERVER_VERSION} \
+          RAY_LATEST_TAG=latest \
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f


### PR DESCRIPTION
Because

- we are using `make latest` for `model` in console test

This commit

- use `RAY_LATEST_TAG=latest` for `Ray` image 
